### PR TITLE
Make available for all ReSharper versions

### DIFF
--- a/src/resharper90.nuspec
+++ b/src/resharper90.nuspec
@@ -23,7 +23,7 @@ The goal of the Community External Annotations project in to provide external an
         <language>en-US</language>
         <tags>Community External Annotations</tags>
         <dependencies>
-            <dependency id="Wave" version="[1.0,4.0]" />
+            <dependency id="Wave" version="1.0" />
         </dependencies>
     </metadata>
     <files>


### PR DESCRIPTION
Annotations are forwards and backwards compatible, so can be made open ended in terms of version dependency.

Fixes #7
