### PR TITLE
Markdown fixes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 ![logo](logo.png)
-#Community Resharper External Annotations
+# Community Resharper External Annotations
 
 The Community ReSharper External Annotations Project is an open source project for ReSharper External Annotations.  It is meant to augment the [official ReSharper External Annotations extension](https://resharper-plugins.jetbrains.com/packages/ReSharper.ExternalAnnotations/ "ReSharper.ExternalAnnotation extension").
 
-##Installation
+## Installation
 
-###ReSharper
+### ReSharper
 
 1. Open Visual Studio
 2. Click ReSharper | Extension Manager...
@@ -14,22 +14,22 @@ The Community ReSharper External Annotations Project is an open source project f
 5. Click "Install" at the bottom of the Extenstion Manager window.
 6. **Restart Visual Studio!**
 
-##Code Annotations
+## Code Annotations
 
 ReSharper performs code inspection and analysis at design time.  It provides feedback based on this analysis to help the developer write better code.  ReSharper relies on [Code Annotations](https://www.jetbrains.com/resharper/help/Code_Analysis__Code_Annotations.html) to better understand the meaning and purpose of source code.    
 
-##Embedding Annotations in Source Code
+## Embedding Annotations in Source Code
 
 The easiest way to use Code Annotations is to [embed them in your source code](https://www.jetbrains.com/resharper/help/Code_Analysis__Annotations_in_Source_Code.html).  However, this is not always practical, feasible, or desirable.
 
-##External Annotations
+## External Annotations
 
 JetBrains introduced [External Annotations](https://www.jetbrains.com/resharper/help/Code_Analysis__External_Annotations.html) to allow developers to annotate third-party assemblies.  External Annotations are defined in XML using syntax similar to C# XML Documentation.  The External Annotations XML file can then be included in the same directory as the assembly being annotated or distributed in a ReSharper extension.
 
-##Goal
+## Goal
 The goal of this project is to augment the official ReSharper.ExternalAnnotations package with additional External Annotations that are either missing from or outside the scope of the official package. 
 
-##Annotated Third-Party APIs
+## Annotated Third-Party APIs
 
 * FluentValidation 5.5.0.0
 * Ninject 3.2.0.0 (includes 3.2.x)
@@ -38,7 +38,7 @@ The goal of this project is to augment the official ReSharper.ExternalAnnotation
 * System.Web.Http 5.2.3.0 (Partially annotated)
 * Prism 5.0 (Partially annotated)
 
-##Annotated .Net Framework Classes
+## Annotated .Net Framework Classes
 
 The following classes, properties, and methods are either partially implemented or missing from the official ReSharper External Annotations package.  If they are added to the official package in the future, they will be removed from this project.
 
@@ -95,7 +95,7 @@ The following classes, properties, and methods are either partially implemented 
 		* P:System.ServiceModel.Channels.MessageVersion.Soap12
 		* P:System.ServiceModel.Channels.MessageVersion.Soap12WSAddressing10
 		* P:System.ServiceModel.Channels.MessageVersion.Soap12WSAddressingAugust2004
-		* P:System.ServiceModel.ClientBase`1.Channel
+		* P:System.ServiceModel.ClientBase\`1.Channel
 		* P:System.ServiceModel.Description.ServiceDescription.Behaviors
 		* P:System.ServiceModel.Dispatcher.ChannelDispatcher.ErrorHandlers
 		* P:System.ServiceModel.Dispatcher.DispatchRuntime.MessageInspectors


### PR DESCRIPTION
GitHub recently [made a slight change to their markdown implementation](https://githubengineering.com/a-formal-spec-for-github-markdown/), which broke header formatting in the README. An unescaped backtick in the list of classes also confused the syntax highlighter in GitHub. This PR fixes both of these cosmetic issues.